### PR TITLE
Tolerate non-string inputs (just return null)

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,8 +8,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: henrikjoreteg/version-compare@main
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
   tests:
     runs-on: ubuntu:latest
     steps:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,20 @@
+name: CI Checks
+
+on: [pull_request, workflow_dispatch]
+
+jobs:
+  has-increased-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: henrikjoreteg/version-compare@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install modules
+        run: npm ci
+      - name: Run unit tests
+        run: npm run ci

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,14 +4,14 @@ on: [pull_request, workflow_dispatch]
 
 jobs:
   has-increased-version:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu:latest
     steps:
       - uses: actions/checkout@v4
       - uses: henrikjoreteg/version-compare@main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
   tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu:latest
     steps:
       - uses: actions/checkout@v4
       - name: Install modules

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ npm test
 
 ## Change log
 
+- `1.1.2`: Updated to always return `null` for non-string inputs
+- `1.1.1`: Updated to support just numbers as a string.
 - `1.0.3`: Added fix for bug with two numbers as input. `12 29` is now `1929-12`.
 - `1.0.2`: Require 3 letters for written months to minimize false positives.
 - `1.0.1`: JS Doc fix.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "parse-dob",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "parse-dob",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "devDependencies": {
         "eslint": "7.19.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "parse-dob",
   "description": "Turn a wide range of freeform inputs describing someone's birth date into `YYYY-MM-DD` using locale to get proper day / month order.",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "author": "Henrik Joreteg <henrik@joreteg.com>",
   "bugs": {
     "url": "https://github.com/henrikjoreteg/parse-dob"

--- a/src/parse-dob.js
+++ b/src/parse-dob.js
@@ -11,7 +11,7 @@ import { testOrder, getCombosToTry, getParts, finalOutput } from './utils.js'
  * @returns {string | null} In format YYYY or YYYY-MM or YYYY-MM-DD
  */
 export default (dobString, locale) => {
-  if (!dobString) return null
+  if (!dobString || typeof dobString !== 'string') return null
 
   const { knownOrder, parts } = getParts(dobString.trim())
   if (knownOrder) {

--- a/src/parse-dob.spec.js
+++ b/src/parse-dob.spec.js
@@ -4,6 +4,7 @@ import getForAllLocales from './locales.js'
 import { toISO } from './utils.js'
 
 const valid = [
+  ['feb 12, 2018', '2018-02-12'],
   ['122982', '1982-12-29'],
   ['291282', '1982-12-29'],
   ['29121982', '1982-12-29'],
@@ -41,9 +42,12 @@ const valid = [
       date: new Date().getDate(),
     }),
   ],
-]
+].slice(0, 1)
 
 const invalid = [
+  [null, null],
+  [{}, null],
+  [undefined, null],
   ['', null],
   ['b', null],
   ['blah', null],
@@ -76,6 +80,7 @@ test('parseDob', t => {
 
   invalid.forEach(([input, output, locale]) => {
     t.equal(
+      // @ts-ignore
       parseDob(input, locale || 'en-US'),
       output,
       `in: ${input} should be ${output}`


### PR DESCRIPTION
This just makes it more resiliant to ignore odd inputs.